### PR TITLE
Fix Windows server

### DIFF
--- a/builds/windows/server/2019/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/server/2019/data/autounattend.pkrtpl.hcl
@@ -85,7 +85,7 @@
             <OSImage>
                <InstallFrom>
                   <MetaData wcm:action="add">
-                     <Key>/IMAGE/NAME</Key>
+                     <Key>/IMAGE/INDEX</Key>
                      <Value>${vm_inst_os_image}</Value>
                   </MetaData>
                </InstallFrom>
@@ -99,10 +99,7 @@
             <AcceptEula>true</AcceptEula>
             <FullName>${build_username}</FullName>
             <Organization>${build_username}</Organization>
-            <ProductKey>
-               <Key>${vm_inst_os_kms_key}</Key>
-               <WillShowUI>OnError</WillShowUI>
-            </ProductKey>
+            <ProductKey/>
          </UserData>
          <EnableFirewall>false</EnableFirewall>
       </component>

--- a/builds/windows/server/2019/variables.pkr.hcl
+++ b/builds/windows/server/2019/variables.pkr.hcl
@@ -74,32 +74,52 @@ variable "vm_inst_os_keyboard" {
 
 variable "vm_inst_os_image_standard_core" {
   type        = string
-  description = "The installation operating system image input for Microsoft Windwows Standard Core."
+  description = "The installation operating system image input for Microsoft Windows Standard Core."
+}
+
+variable "vm_inst_os_image_standard_core_index" {
+  type        = number
+  description = "The installation operating system image index within install.wim for Microsoft Windows Standard Core."
 }
 
 variable "vm_inst_os_image_standard_desktop" {
   type        = string
-  description = "The installation operating system image input for Microsoft Windwows Standard."
+  description = "The installation operating system image index within install.wim for Microsoft Windows Standard."
+}
+
+variable "vm_inst_os_image_standard_desktop_index" {
+  type        = number
+  description = "The installation operating system image input for Microsoft Windows Standard."
 }
 
 variable "vm_inst_os_kms_key_standard" {
   type        = string
-  description = "The installation operating system KMS key input for Microsoft Windwows Standard edition."
+  description = "The installation operating system KMS key input for Microsoft Windows Standard edition."
 }
 
 variable "vm_inst_os_image_datacenter_core" {
   type        = string
-  description = "The installation operating system image input for Microsoft Windwows Datacenter Core."
+  description = "The installation operating system image input for Microsoft Windows Datacenter Core."
+}
+
+variable "vm_inst_os_image_datacenter_core_index" {
+  type        = number
+  description = "The installation operating system image index within install.wim for Microsoft Windows Datacenter Core."
 }
 
 variable "vm_inst_os_image_datacenter_desktop" {
   type        = string
-  description = "The installation operating system image input for Microsoft Windwows Datacenter."
+  description = "The installation operating system image input for Microsoft Windows Datacenter."
+}
+
+variable "vm_inst_os_image_datacenter_desktop_index" {
+  type        = number
+  description = "The installation operating system image index within install.wim for Microsoft Windows Datacenter."
 }
 
 variable "vm_inst_os_kms_key_datacenter" {
   type        = string
-  description = "The installation operating system KMS key input for Microsoft Windwows Datacenter edition."
+  description = "The installation operating system KMS key input for Microsoft Windows Datacenter edition."
 }
 
 // Virtual Machine Settings

--- a/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
@@ -13,6 +13,16 @@ vm_inst_os_image_datacenter_core    = "Windows Server 2019 SERVERDATACENTERCORE"
 vm_inst_os_image_datacenter_desktop = "Windows Server 2019 SERVERDATACENTER"
 vm_inst_os_kms_key_datacenter       = "WMDGN-G9PQG-XVVXX-R3X43-63DFG"
 
+/*
+  Selecting OS versions via an index is more reliable than using
+   the string value of the OS version. For both Windows 2019 and 2022
+   ISO's, the order will be the same as below.
+*/
+vm_inst_os_image_standard_core_index = 1
+vm_inst_os_image_standard_desktop_index = 2
+vm_inst_os_image_datacenter_core_index = 3
+vm_inst_os_image_datacenter_desktop_index = 4
+
 // Guest Operating System Metadata
 vm_guest_os_language           = "en-US"
 vm_guest_os_keyboard           = "en-US"
@@ -31,21 +41,29 @@ vm_guest_os_type = "windows2019srv_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 1
-vm_cpu_cores             = 2
+// vm_cpu_sockets is equivalent
+// to the amount of vCPU's assigned
+// to an instance. This name
+// differs from upstream.
+vm_cpu_sockets           = 2
+vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 8192
 vm_mem_hot_add           = false
-vm_disk_size             = 80000
+vm_disk_size             = 40000
 vm_disk_controller_type  = ["pvscsi"]
 vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
-iso_path           = "_ISOs/Windows"
-iso_file           = "en-us_windows_server_2019_updated_aug_2021_x64_dvd_a6431a28.iso"
+// Note that these are specific
+// to the current vSphere environment,
+// and should changed when ISOs are uploaded
+// or removed
+iso_path           = "iso"
+iso_file           = "windows_2019_evaluation_edition.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "0067AFE7FDC4E61F677BD8C35A209082AA917DF9C117527FC4B2B52A447E89BB"
+iso_checksum_value = "6dae072e7f78f4ccab74a45341de0d6e2d45c39be25f1f5920a2ab4f51d7bcbb"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"

--- a/builds/windows/server/2019/windows-server.pkr.hcl
+++ b/builds/windows/server/2019/windows-server.pkr.hcl
@@ -87,7 +87,7 @@ source "vsphere-iso" "windows-server-standard-core" {
       build_password       = var.build_password
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_standard_core
+      vm_inst_os_image     = var.vm_inst_os_image_standard_core_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_standard
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard
@@ -178,7 +178,7 @@ source "vsphere-iso" "windows-server-standard-dexp" {
       build_password       = var.build_password
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_standard_desktop
+      vm_inst_os_image     = var.vm_inst_os_image_standard_desktop_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_standard
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard
@@ -271,7 +271,7 @@ source "vsphere-iso" "windows-server-datacenter-core" {
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_datacenter_core
+      vm_inst_os_image     = var.vm_inst_os_image_datacenter_core_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_datacenter
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard
@@ -361,7 +361,7 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
       build_password       = var.build_password
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_datacenter_desktop
+      vm_inst_os_image     = var.vm_inst_os_image_datacenter_desktop_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_datacenter
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard

--- a/builds/windows/server/2022/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/server/2022/data/autounattend.pkrtpl.hcl
@@ -85,7 +85,7 @@
             <OSImage>
                <InstallFrom>
                   <MetaData wcm:action="add">
-                     <Key>/IMAGE/NAME</Key>
+                     <Key>/IMAGE/INDEX</Key>
                      <Value>${vm_inst_os_image}</Value>
                   </MetaData>
                </InstallFrom>
@@ -96,10 +96,7 @@
             <AcceptEula>true</AcceptEula>
             <FullName>${build_username}</FullName>
             <Organization>${build_username}</Organization>
-            <ProductKey>
-               <Key>${vm_inst_os_kms_key}</Key>
-               <WillShowUI>OnError</WillShowUI>
-            </ProductKey>
+            <ProductKey/>
          </UserData>
          <EnableFirewall>false</EnableFirewall>
       </component>

--- a/builds/windows/server/2022/variables.pkr.hcl
+++ b/builds/windows/server/2022/variables.pkr.hcl
@@ -421,11 +421,18 @@ variable "communicator_timeout" {
 
 // Provisioner Settings
 
-variable "scripts" {
+variable "preparationScripts" {
   type        = list(string)
   description = "A list of scripts and their relative paths to transfer and run."
   default     = []
 }
+
+variable "finishScripts" {
+  type        = list(string)
+  description = "A list of finishing scripts to run."
+  default     = []
+}
+
 
 variable "inline" {
   type        = list(string)

--- a/builds/windows/server/2022/variables.pkr.hcl
+++ b/builds/windows/server/2022/variables.pkr.hcl
@@ -77,8 +77,18 @@ variable "vm_inst_os_image_standard_core" {
   description = "The installation operating system image input for Microsoft Windwows Standard Core."
 }
 
+variable "vm_inst_os_image_standard_core_index" {
+  type        = number
+  description = "The installation operating system image input for Microsoft Windwows Standard Core."
+}
+
 variable "vm_inst_os_image_standard_desktop" {
   type        = string
+  description = "The installation operating system image input for Microsoft Windwows Standard."
+}
+
+variable "vm_inst_os_image_standard_desktop_index" {
+  type        = number
   description = "The installation operating system image input for Microsoft Windwows Standard."
 }
 
@@ -92,8 +102,18 @@ variable "vm_inst_os_image_datacenter_core" {
   description = "The installation operating system image input for Microsoft Windwows Datacenter Core."
 }
 
+variable "vm_inst_os_image_datacenter_core_index" {
+  type        = number
+  description = "The installation operating system image input for Microsoft Windwows Datacenter Core."
+}
+
 variable "vm_inst_os_image_datacenter_desktop" {
   type        = string
+  description = "The installation operating system image input for Microsoft Windwows Datacenter."
+}
+
+variable "vm_inst_os_image_datacenter_desktop_index" {
+  type        = number
   description = "The installation operating system image input for Microsoft Windwows Datacenter."
 }
 

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -13,6 +13,17 @@ vm_inst_os_image_datacenter_core    = "Windows Server 2022 SERVERDATACENTERCORE"
 vm_inst_os_image_datacenter_desktop = "Windows Server 2022 SERVERDATACENTER"
 vm_inst_os_kms_key_datacenter       = "WX4NM-KYWYW-QJJR4-XV3QB-6VM33"
 
+/*
+  Selecting OS versions via an index is more reliable than using
+   the string value of the OS version. For both Windows 2019 and 2022
+   ISO's, the order will be the same as below.
+*/
+vm_inst_os_image_standard_core_index = 1
+vm_inst_os_image_standard_desktop_index = 2
+vm_inst_os_image_datacenter_core_index = 3
+vm_inst_os_image_datacenter_desktop_index = 4
+
+
 // Guest Operating System Metadata
 vm_guest_os_language           = "en-US"
 vm_guest_os_keyboard           = "en-US"
@@ -31,19 +42,27 @@ vm_guest_os_type = "windows2019srv_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 1
-vm_cpu_cores             = 2
+// vm_cpu_sockets is equivalent
+// to the amount of vCPU's assigned
+// to an instance. This name
+// differs from upstream.
+vm_cpu_sockets           = 2
+vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 8192
 vm_mem_hot_add           = false
-vm_disk_size             = 80000
+vm_disk_size             = 40000
 vm_disk_controller_type  = ["pvscsi"]
 vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
-iso_path           = "iso/windows/server"
-iso_file           = "en-us_windows_server_2022_updated_feb_2022_x64_dvd_d4a089c1.iso"
+// Note that these are specific
+// to the current vSphere environment,
+// and should changed when ISOs are uploaded
+// or removed
+iso_path           = "iso"
+iso_file           = "windows-2022.iso"
 iso_checksum_type  = "sha256"
 iso_checksum_value = "5140AC5FB8F48EFDF4BFCF1E7BE14030F9164A824F12A9D08A45CDC72DAC8D15"
 

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -77,8 +77,6 @@ communicator_port    = 5985
 communicator_timeout = "12h"
 
 // Provisioner Settings
-scripts = ["scripts/windows/windows-prepare.ps1"]
-inline = [
-  "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
-  "choco feature enable -n allowGlobalConfirmation"
-]
+preparationScripts = ["scripts/windows/windows-prepare.ps1"]
+finishScripts = ["scripts/windows/windows-finish.ps1"]
+

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -87,7 +87,7 @@ source "vsphere-iso" "windows-server-standard-core" {
       build_password       = var.build_password
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_standard_core
+      vm_inst_os_image     = var.vm_inst_os_image_standard_core_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_standard
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard
@@ -178,7 +178,7 @@ source "vsphere-iso" "windows-server-standard-dexp" {
       build_password       = var.build_password
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_standard_desktop
+      vm_inst_os_image     = var.vm_inst_os_image_standard_desktop_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_standard
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard
@@ -271,7 +271,7 @@ source "vsphere-iso" "windows-server-datacenter-core" {
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_datacenter_core
+      vm_inst_os_image     = var.vm_inst_os_image_datacenter_core_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_datacenter
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard
@@ -362,7 +362,7 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
       build_password       = var.build_password
       vm_inst_os_language  = var.vm_inst_os_language
       vm_inst_os_keyboard  = var.vm_inst_os_keyboard
-      vm_inst_os_image     = var.vm_inst_os_image_datacenter_desktop
+      vm_inst_os_image     = var.vm_inst_os_image_datacenter_desktop_index
       vm_inst_os_kms_key   = var.vm_inst_os_kms_key_datacenter
       vm_guest_os_language = var.vm_guest_os_language
       vm_guest_os_keyboard = var.vm_guest_os_keyboard

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -442,13 +442,16 @@ build {
     ]
     elevated_user     = var.build_username
     elevated_password = var.build_password
-    scripts           = formatlist("${path.cwd}/%s", var.scripts)
+    scripts           = formatlist("${path.cwd}/%s", var.preparationScripts)
   }
 
   provisioner "powershell" {
+    environment_vars = [
+      "BUILD_USERNAME=${var.build_username}"
+    ]
     elevated_user     = var.build_username
     elevated_password = var.build_password
-    inline            = var.inline
+    scripts           = formatlist("${path.cwd}/%s", var.finishScripts)
   }
 
   provisioner "windows-update" {

--- a/scripts/windows/windows-prepare.ps1
+++ b/scripts/windows/windows-prepare.ps1
@@ -81,6 +81,11 @@ Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 
 # Install Chocolatey
 Write-Output "Installing Chocolatey..."
+
+# Bandaid. Force Chocolatey to 1.4.0. This version does not require DotNet Framework 4.8, which simplfies the install scripts.
+# If this bandaid falls off in the future, an additional step needs to be added to properly reboot the instance after DotNet
+# Framework 4.8 is installed by Chocolately (potentially by disabling the firewall in the windows-finish.ps1 script).
+$env:chocolateyVersion = '1.4.0'
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 choco feature enable -n allowGlobalConfirmation
 


### PR DESCRIPTION
This PR fixes Packer builds for Windows server 2019 and 2022. 

The root issue that was fixed was how the `autounattend.xml` file specified the version of windows to install from a given ISO. 

Each windows ISO contains an index file, `install.wim`, which lists all of the possible versions of Windows which can be installed. Previously we were using a string value to select the OS version we wanted from `install.wim`, however this is somewhat unreliable as these version strings may differ as new ISO's are released. This PR changes the `autounattend.xml` file to use the the index number listed within `install.wim` to select particular OS versions.

There is still a chance that a particular ISO may not work with this system (e.g. only 1 version is available in the ISO, or the indexes for versions change), however this is still more reliable than using the string value.

Other changes
+ Updated `hcl` files to use new index based OS version selection 
+ Fixed an issue within `windows-prepare.ps1` which prevented Chocolately from being installed properly due to new requirement of DotNet Framework 4.8
+ Removed Windows Product Keys from `autounattend.xml` files. These product keys were being used in conjunction with the OS version string to identify what version to install. The evaluation ISO's already have a key embedded within them, so removing them is safe and results in proper version selection. 
+ `Windwows` -> `Windows`
